### PR TITLE
DecisionRequester check if component is active

### DIFF
--- a/com.unity.ml-agents/Runtime/DecisionRequester.cs
+++ b/com.unity.ml-agents/Runtime/DecisionRequester.cs
@@ -96,6 +96,10 @@ namespace Unity.MLAgents
         /// <param name="academyStepCount">The current step count of the academy.</param>
         void MakeRequests(int academyStepCount)
         {
+            // this event is always triggered, check if component is enabled
+            if(!isActiveAndEnabled){
+                return;
+            }
             var context = new DecisionRequestContext
             {
                 AcademyStepCount = academyStepCount


### PR DESCRIPTION
### Proposed change(s)

DecisionRequester is triggered by events so doesn't currently respect the component being disabled.

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)



### Types of change(s)

- [x ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments

Seems like this should be the expected behavior. Small change but not sure what surrounding documentation is required.